### PR TITLE
Fixed blocks state <-> meta conversion

### DIFF
--- a/src/main/java/appeng/block/AEBaseBlock.java
+++ b/src/main/java/appeng/block/AEBaseBlock.java
@@ -67,7 +67,7 @@ import appeng.util.Platform;
 public abstract class AEBaseBlock extends Block implements IAEFeature
 {
 
-	public static final PropertyEnum AXIS_ORIENTATION = PropertyEnum.create( "axis", EnumFacing.Axis.class );
+	public static final PropertyEnum<EnumFacing.Axis> AXIS_ORIENTATION = PropertyEnum.create( "axis", EnumFacing.Axis.class );
 
 	private final String featureFullName;
 	private final Optional<String> featureSubName;

--- a/src/main/java/appeng/block/misc/BlockQuartzTorch.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzTorch.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockTorch;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyDirection;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
@@ -52,11 +52,15 @@ import appeng.helpers.MetaRotation;
 
 public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, ICustomCollision
 {
+	
+	// Cannot use the vanilla FACING property here because it excludes facing DOWN
+	public static final PropertyDirection FACING = PropertyDirection.create("facing");
+	
 	public BlockQuartzTorch()
 	{
 		super( Material.CIRCUITS );
 
-		this.setDefaultState(this.blockState.getBaseState().withProperty(BlockTorch.FACING, EnumFacing.UP));
+		this.setDefaultState(this.blockState.getBaseState().withProperty(FACING, EnumFacing.UP));
 		this.setFeature( EnumSet.of( AEFeature.DecorativeLights ) );
 		this.setLightLevel( 0.9375F );
 		this.setLightOpacity( 0 );
@@ -67,48 +71,20 @@ public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, I
 	@Override
 	public int getMetaFromState( final IBlockState state )
 	{
-		switch (state.getValue(BlockTorch.FACING))
-		{
-			case EAST:
-				return 1;
-			case WEST:
-				return 2;
-			case SOUTH:
-				return 3;
-			case NORTH:
-				return 4;
-			case DOWN:
-			case UP:
-			default:
-				return 5;
-		}
+		return state.getValue(FACING).ordinal();
 	}
 
 	@Override
 	public IBlockState getStateFromMeta( final int meta )
 	{
-		IBlockState state = this.getDefaultState();
-
-		switch (meta)
-		{
-			case 1:
-				return state.withProperty(BlockTorch.FACING, EnumFacing.EAST);
-			case 2:
-				return state.withProperty(BlockTorch.FACING, EnumFacing.WEST);
-			case 3:
-				return state.withProperty(BlockTorch.FACING, EnumFacing.SOUTH);
-			case 4:
-				return state.withProperty(BlockTorch.FACING, EnumFacing.NORTH);
-			case 5:
-			default:
-				return state.withProperty(BlockTorch.FACING, EnumFacing.UP);
-		}
+		EnumFacing facing = EnumFacing.values()[meta];
+		return getDefaultState().withProperty(FACING, facing);
 	}
 
 	@Override
 	protected IProperty[] getAEStates()
 	{
-		return new IProperty[] { BlockTorch.FACING };
+		return new IProperty[] { FACING };
 	}
 
 	@Override
@@ -210,6 +186,6 @@ public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, I
 	@Override
 	public IOrientable getOrientable( final IBlockAccess w, final BlockPos pos )
 	{
-		return new MetaRotation( w, pos, true );
+		return new MetaRotation( w, pos, FACING );
 	}
 }

--- a/src/main/java/appeng/block/misc/BlockQuartzTorch.java
+++ b/src/main/java/appeng/block/misc/BlockQuartzTorch.java
@@ -56,6 +56,7 @@ public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, I
 	{
 		super( Material.CIRCUITS );
 
+		this.setDefaultState(this.blockState.getBaseState().withProperty(BlockTorch.FACING, EnumFacing.UP));
 		this.setFeature( EnumSet.of( AEFeature.DecorativeLights ) );
 		this.setLightLevel( 0.9375F );
 		this.setLightOpacity( 0 );
@@ -66,13 +67,42 @@ public class BlockQuartzTorch extends AEBaseBlock implements IOrientableBlock, I
 	@Override
 	public int getMetaFromState( final IBlockState state )
 	{
-		return 0;
+		switch (state.getValue(BlockTorch.FACING))
+		{
+			case EAST:
+				return 1;
+			case WEST:
+				return 2;
+			case SOUTH:
+				return 3;
+			case NORTH:
+				return 4;
+			case DOWN:
+			case UP:
+			default:
+				return 5;
+		}
 	}
 
 	@Override
 	public IBlockState getStateFromMeta( final int meta )
 	{
-		return this.getDefaultState();
+		IBlockState state = this.getDefaultState();
+
+		switch (meta)
+		{
+			case 1:
+				return state.withProperty(BlockTorch.FACING, EnumFacing.EAST);
+			case 2:
+				return state.withProperty(BlockTorch.FACING, EnumFacing.WEST);
+			case 3:
+				return state.withProperty(BlockTorch.FACING, EnumFacing.SOUTH);
+			case 4:
+				return state.withProperty(BlockTorch.FACING, EnumFacing.NORTH);
+			case 5:
+			default:
+				return state.withProperty(BlockTorch.FACING, EnumFacing.UP);
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/decorative/solid/QuartzPillarBlock.java
+++ b/src/main/java/appeng/decorative/solid/QuartzPillarBlock.java
@@ -73,7 +73,7 @@ public class QuartzPillarBlock extends AEBaseBlock implements IOrientableBlock
 	@Override
 	public IOrientable getOrientable( final IBlockAccess w, final BlockPos pos )
 	{
-		return new MetaRotation( w, pos, false );
+		return new MetaRotation( w, pos, null );
 	}
 
 }

--- a/src/main/java/appeng/decorative/solid/QuartzPillarBlock.java
+++ b/src/main/java/appeng/decorative/solid/QuartzPillarBlock.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
@@ -34,7 +35,6 @@ import appeng.core.features.AEFeature;
 import appeng.helpers.MetaRotation;
 
 
-// TODO Quartz Rotation.
 public class QuartzPillarBlock extends AEBaseBlock implements IOrientableBlock
 {
 
@@ -47,13 +47,15 @@ public class QuartzPillarBlock extends AEBaseBlock implements IOrientableBlock
 	@Override
 	public int getMetaFromState( final IBlockState state )
 	{
-		return 0;
+		return state.getValue(AXIS_ORIENTATION).ordinal();
 	}
 
 	@Override
 	public IBlockState getStateFromMeta( final int meta )
 	{
-		return this.getDefaultState();
+	    // Simply use the ordinal here
+	    EnumFacing.Axis axis = EnumFacing.Axis.values()[meta];
+		return this.getDefaultState().withProperty(AXIS_ORIENTATION, axis);
 	}
 
 	@Override

--- a/src/main/java/appeng/helpers/MetaRotation.java
+++ b/src/main/java/appeng/helpers/MetaRotation.java
@@ -19,7 +19,7 @@
 package appeng.helpers;
 
 
-import net.minecraft.block.BlockTorch;
+import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
@@ -34,15 +34,15 @@ import appeng.block.AEBaseBlock;
 public class MetaRotation implements IOrientable
 {
 
-	private final boolean useFacing;
+	private final IProperty<EnumFacing> facingProp;
 	private final IBlockAccess w;
 	private final BlockPos pos;
 
-	public MetaRotation( final IBlockAccess world, final BlockPos pos, final boolean FullFacing )
+	public MetaRotation( final IBlockAccess world, final BlockPos pos, final IProperty<EnumFacing> facingProp )
 	{
 		this.w = world;
 		this.pos = pos;
-		this.useFacing = FullFacing;
+		this.facingProp = facingProp;
 	}
 
 	@Override
@@ -66,13 +66,12 @@ public class MetaRotation implements IOrientable
 	{
 		final IBlockState state = this.w.getBlockState( this.pos );
 
-		if( this.useFacing )
+		if( this.facingProp != null )
 		{
-			final EnumFacing f = state == null ? EnumFacing.UP : (EnumFacing) state.getValue( BlockTorch.FACING );
-			return f;
+			return state.getValue( facingProp );
 		}
 
-		Axis a = state == null ? null : (Axis) state.getValue( AEBaseBlock.AXIS_ORIENTATION );
+		Axis a = state.getValue( AEBaseBlock.AXIS_ORIENTATION );
 
 		if( a == null )
 		{
@@ -96,9 +95,9 @@ public class MetaRotation implements IOrientable
 	{
 		if( this.w instanceof World )
 		{
-			if( this.useFacing )
+			if( facingProp != null )
 			{
-				( (World) this.w ).setBlockState( this.pos, this.w.getBlockState( this.pos ).withProperty( BlockTorch.FACING, up ) );
+				( (World) this.w ).setBlockState( this.pos, this.w.getBlockState( this.pos ).withProperty( facingProp, up ) );
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #23.

The getMetaFromState and getStateFromMeta methods need to be implemented to convert the block states into a meta value that gets actually written to the savegame for the block.

p.s.: I simply used the enum ordinal here. I toyed with the idea to use a switch, but it seems unlikely they're going to go 4D anytime soon ;-).
