### PR TITLE
Fixed Particle Effect Corruption

### DIFF
--- a/src/main/java/appeng/client/render/effects/CraftingFx.java
+++ b/src/main/java/appeng/client/render/effects/CraftingFx.java
@@ -93,12 +93,16 @@ public class CraftingFx extends ParticleBreaking
 			offY -= interpPosY;
 			offZ -= interpPosZ;
 
+			int i = this.getBrightnessForRender(partialTick);
+			int j = i >> 16 & 65535;
+			int k = i & 65535;
+
 			// AELog.info( "" + partialTick );
 			final float f14 = 1.0F;
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( offX - x * scale - rx * scale, offY - y * scale, offZ - z * scale - rz * scale ).tex( f7, f9 ).endVertex();
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( offX - x * scale + rx * scale, offY + y * scale, offZ - z * scale + rz * scale ).tex( f7, f8 ).endVertex();
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( offX + x * scale + rx * scale, offY + y * scale, offZ + z * scale + rz * scale ).tex( f6, f8 ).endVertex();
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( offX + x * scale - rx * scale, offY - y * scale, offZ + z * scale - rz * scale ).tex( f6, f9 ).endVertex();
+			par1Tessellator.pos( offX - x * scale - rx * scale, offY - y * scale, offZ - z * scale - rz * scale ).tex( f7, f9 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+			par1Tessellator.pos( offX - x * scale + rx * scale, offY + y * scale, offZ - z * scale + rz * scale ).tex( f7, f8 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+			par1Tessellator.pos( offX + x * scale + rx * scale, offY + y * scale, offZ + z * scale + rz * scale ).tex( f6, f8 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+			par1Tessellator.pos( offX + x * scale - rx * scale, offY - y * scale, offZ + z * scale - rz * scale ).tex( f6, f9 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
 		}
 	}
 

--- a/src/main/java/appeng/client/render/effects/EnergyFx.java
+++ b/src/main/java/appeng/client/render/effects/EnergyFx.java
@@ -84,11 +84,15 @@ public class EnergyFx extends ParticleBreaking
 
 		if( blkX == this.startBlkX && blkY == this.startBlkY && blkZ == this.startBlkZ )
 		{
+			int i = this.getBrightnessForRender(par2);
+			int j = i >> 16 & 65535;
+			int k = i & 65535;
+
 			final float f14 = 1.0F;
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 - par3 * f10 - par6 * f10, f12 - par4 * f10, f13 - par5 * f10 - par7 * f10 ).tex( f7, f9 ).endVertex();
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 - par3 * f10 + par6 * f10, f12 + par4 * f10, f13 - par5 * f10 + par7 * f10 ).tex( f7, f8 ).endVertex();
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 + par3 * f10 + par6 * f10, f12 + par4 * f10, f13 + par5 * f10 + par7 * f10 ).tex( f6, f8 ).endVertex();
-			par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 + par3 * f10 - par6 * f10, f12 - par4 * f10, f13 + par5 * f10 - par7 * f10 ).tex( f6, f9 ).endVertex();
+			par1Tessellator.pos( f11 - par3 * f10 - par6 * f10, f12 - par4 * f10, f13 - par5 * f10 - par7 * f10 ).tex( f7, f9 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+			par1Tessellator.pos( f11 - par3 * f10 + par6 * f10, f12 + par4 * f10, f13 - par5 * f10 + par7 * f10 ).tex( f7, f8 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+			par1Tessellator.pos( f11 + par3 * f10 + par6 * f10, f12 + par4 * f10, f13 + par5 * f10 + par7 * f10 ).tex( f6, f8 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+			par1Tessellator.pos( f11 + par3 * f10 - par6 * f10, f12 - par4 * f10, f13 + par5 * f10 - par7 * f10 ).tex( f6, f9 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
 		}
 	}
 

--- a/src/main/java/appeng/client/render/effects/LightningFX.java
+++ b/src/main/java/appeng/client/render/effects/LightningFX.java
@@ -35,6 +35,7 @@ public class LightningFX extends Particle
 
 	private static final Random RANDOM_GENERATOR = new Random();
 	private static final int STEPS = 5;
+	private static final int BRIGHTNESS = 13 << 4;
 
 	private final double[][] precomputedSteps;
 	private final double[] vertices = new double[3];
@@ -75,13 +76,6 @@ public class LightningFX extends Particle
 		return LightningFX.STEPS;
 	}
 
-	@Override
-	public int getBrightnessForRender( final float par1 )
-	{
-		final int j1 = 13;
-		return j1 << 20 | j1 << 4;
-	}
-	
 	@Override
 	public void onUpdate()
 	{
@@ -232,10 +226,10 @@ public class LightningFX extends Particle
 	{
 		if( this.hasData )
 		{
-			tess.color( red, green, blue, this.particleAlpha ).pos( a[0], a[1], a[2] ).tex( f6, f8 ).endVertex();
-			tess.color( red, green, blue, this.particleAlpha ).pos( this.vertices[0], this.vertices[1], this.vertices[2] ).tex( f6, f8 ).endVertex();
-			tess.color( red, green, blue, this.particleAlpha ).pos( this.verticesWithUV[0], this.verticesWithUV[1], this.verticesWithUV[2] ).tex( f6, f8 ).endVertex();
-			tess.color( red, green, blue, this.particleAlpha ).pos( b[0], b[1], b[2] ).tex( f6, f8 ).endVertex();
+			tess.pos( a[0], a[1], a[2] ).tex( f6, f8 ).color( red, green, blue, this.particleAlpha ).lightmap( BRIGHTNESS, BRIGHTNESS ).endVertex();
+			tess.pos( this.vertices[0], this.vertices[1], this.vertices[2] ).tex( f6, f8 ).color( red, green, blue, this.particleAlpha ).lightmap( BRIGHTNESS, BRIGHTNESS ).endVertex();
+			tess.pos( this.verticesWithUV[0], this.verticesWithUV[1], this.verticesWithUV[2] ).tex( f6, f8 ).color( red, green, blue, this.particleAlpha ).lightmap( BRIGHTNESS, BRIGHTNESS ).endVertex();
+			tess.pos( b[0], b[1], b[2] ).tex( f6, f8 ).color( red, green, blue, this.particleAlpha ).lightmap( BRIGHTNESS, BRIGHTNESS ).endVertex();
 		}
 		this.hasData = true;
 		for( int x = 0; x < 3; x++ )

--- a/src/main/java/appeng/client/render/effects/MatterCannonFX.java
+++ b/src/main/java/appeng/client/render/effects/MatterCannonFX.java
@@ -97,9 +97,13 @@ public class MatterCannonFX extends ParticleBreaking
 		final float f13 = (float) ( this.prevPosZ + ( this.posZ - this.prevPosZ ) * par2 - interpPosZ );
 		final float f14 = 1.0F;
 
-		par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 - par3 * f10 - par6 * f10, f12 - par4 * f10, f13 - par5 * f10 - par7 * f10 ).tex( f7, f9 );
-		par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 - par3 * f10 + par6 * f10, f12 + par4 * f10, f13 - par5 * f10 + par7 * f10 ).tex( f7, f8 );
-		par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 + par3 * f10 + par6 * f10, f12 + par4 * f10, f13 + par5 * f10 + par7 * f10 ).tex( f6, f8 );
-		par1Tessellator.color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).pos( f11 + par3 * f10 - par6 * f10, f12 - par4 * f10, f13 + par5 * f10 - par7 * f10 ).tex( f6, f9 );
+		int i = this.getBrightnessForRender(par2);
+		int j = i >> 16 & 65535;
+		int k = i & 65535;
+
+		par1Tessellator.pos( f11 - par3 * f10 - par6 * f10, f12 - par4 * f10, f13 - par5 * f10 - par7 * f10 ).tex( f7, f9 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+		par1Tessellator.pos( f11 - par3 * f10 + par6 * f10, f12 + par4 * f10, f13 - par5 * f10 + par7 * f10 ).tex( f7, f8 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+		par1Tessellator.pos( f11 + par3 * f10 + par6 * f10, f12 + par4 * f10, f13 + par5 * f10 + par7 * f10 ).tex( f6, f8 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
+		par1Tessellator.pos( f11 + par3 * f10 - par6 * f10, f12 - par4 * f10, f13 + par5 * f10 - par7 * f10 ).tex( f6, f9 ).color( this.particleRed * f14, this.particleGreen * f14, this.particleBlue * f14, this.particleAlpha ).lightmap( j, k ).endVertex();
 	}
 }


### PR DESCRIPTION
This fixes issue #11.

The Particle FX classes were using a different ordering for the vertex attributes than Minecraft. This caused the color to be interpreted as the position and some other funkyness.
I copied the vertex attribute ordering from the Vanilla base class and did this for all the FX classes that override renderParticle.

This is how it looks now:
![Particle FX](https://i.imgur.com/5yvDU9V.jpg)

They seem to look very slightly thicker than in 1.7, but that can be fixed later. In addition, the Particle FX classes definitely need some love w.r.t. to code quality, but i wanted to keep this PR small.
