### PR TITLE
Fixes Paintball Item Rendering

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -31,7 +31,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.color.IBlockColor;
-import net.minecraft.client.renderer.color.IItemColor;
+import net.minecraft.client.renderer.color.ItemColors;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -129,7 +129,10 @@ public class ClientHelper extends ServerHelper
 			}
 		}
 
-		Minecraft.getMinecraft().getItemColors().registerItemColorHandler( new ItemPaintBallColor(), Api.INSTANCE.definitions().items().paintBall().maybeItem().get() );
+		// Register color handling for paintball items
+		ItemColors itemColors = Minecraft.getMinecraft().getItemColors();
+		Item paintballItem = Api.INSTANCE.definitions().items().paintBall().maybeItem().get();
+		itemColors.registerItemColorHandler( ItemPaintBall::getColorFromItemstack, paintballItem );
 	}
 
 	@Override
@@ -464,30 +467,4 @@ public class ClientHelper extends ServerHelper
 		}
 	}
 
-
-	public class ItemPaintBallColor implements IItemColor
-	{
-
-		@Override
-		public int getColorFromItemstack( ItemStack stack, int tintIndex )
-		{
-			final AEColor col = ( (ItemPaintBall) stack.getItem() ).getColor( stack );
-
-			final int colorValue = stack.getItemDamage() >= 20 ? col.mediumVariant : col.mediumVariant;
-			final int r = ( colorValue >> 16 ) & 0xff;
-			final int g = ( colorValue >> 8 ) & 0xff;
-			final int b = ( colorValue ) & 0xff;
-
-			if( stack.getItemDamage() >= 20 )
-			{
-				final float fail = 0.7f;
-				final int full = (int) ( 255 * 0.3 );
-				return (int) ( full + r * fail ) << 16 | (int) ( full + g * fail ) << 8 | (int) ( full + b * fail ) | 0xff << 24;
-			}
-			else
-			{
-				return r << 16 | g << 8 | b | 0xff << 24;
-			}
-		}
-	}
 }

--- a/src/main/java/appeng/core/features/ItemFeatureHandler.java
+++ b/src/main/java/appeng/core/features/ItemFeatureHandler.java
@@ -25,7 +25,6 @@ import com.google.common.base.Optional;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemMeshDefinition;
-import net.minecraft.client.renderer.ItemModelMesher;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -138,8 +137,7 @@ public final class ItemFeatureHandler implements IFeatureHandler
 
 		if( meshDefinition != null )
 		{
-			ItemModelMesher itemModelMesher = Minecraft.getMinecraft().getRenderItem().getItemModelMesher();
-			itemModelMesher.register( item, meshDefinition );
+			Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register( item, meshDefinition );
 		}
 		else
 		{

--- a/src/main/java/appeng/core/features/ItemFeatureHandler.java
+++ b/src/main/java/appeng/core/features/ItemFeatureHandler.java
@@ -24,6 +24,8 @@ import java.util.EnumSet;
 import com.google.common.base.Optional;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemMeshDefinition;
+import net.minecraft.client.renderer.ItemModelMesher;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -37,6 +39,7 @@ import appeng.api.definitions.IItemDefinition;
 import appeng.core.AppEng;
 import appeng.core.CreativeTab;
 import appeng.core.CreativeTabFacade;
+import appeng.items.AEBaseItem;
 import appeng.items.parts.ItemFacade;
 
 
@@ -105,7 +108,18 @@ public final class ItemFeatureHandler implements IFeatureHandler
 
 			if( side == Side.CLIENT )
 			{
-				ModelBakery.registerItemVariants( item, registryName );
+				if( item instanceof AEBaseItem )
+				{
+					AEBaseItem baseItem = (AEBaseItem) item;
+
+					// Handle registration of item variants
+					ResourceLocation[] variants = baseItem.getItemVariants().toArray( new ResourceLocation[0] );
+					ModelBakery.registerItemVariants( item, variants );
+				}
+				else
+				{
+					ModelBakery.registerItemVariants( item, registryName );
+				}
 			}
 		}
 	}
@@ -113,7 +127,24 @@ public final class ItemFeatureHandler implements IFeatureHandler
 	@Override
 	public void registerModel()
 	{
-		Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register( item, 0, new ModelResourceLocation( registryName, "inventory" ) );
+		ItemMeshDefinition meshDefinition = null;
+
+		// Register a custom item model handler if the item wants one
+		if( item instanceof AEBaseItem )
+		{
+			AEBaseItem baseItem = (AEBaseItem) item;
+			meshDefinition = baseItem.getItemMeshDefinition();
+		}
+
+		if( meshDefinition != null )
+		{
+			ItemModelMesher itemModelMesher = Minecraft.getMinecraft().getRenderItem().getItemModelMesher();
+			itemModelMesher.register( item, meshDefinition );
+		}
+		else
+		{
+			Minecraft.getMinecraft().getRenderItem().getItemModelMesher().register( item, 0, new ModelResourceLocation( registryName, "inventory" ) );
+		}
 	}
 
 	@Override

--- a/src/main/java/appeng/items/AEBaseItem.java
+++ b/src/main/java/appeng/items/AEBaseItem.java
@@ -23,16 +23,17 @@ import java.util.EnumSet;
 import java.util.List;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 
-import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import appeng.client.ClientHelper;
 import appeng.core.features.AEFeature;
 import appeng.core.features.FeatureNameExtractor;
 import appeng.core.features.IAEFeature;
@@ -106,11 +107,27 @@ public abstract class AEBaseItem extends Item implements IAEFeature
 		super.addInformation( stack, player, lines, displayMoreInfo );
 	}
 
-	@SideOnly( Side.CLIENT )
-	public void registerCustomIcon( final TextureMap map ){}
-
 	protected void getCheckedSubItems( final Item sameItem, final CreativeTabs creativeTab, final List<ItemStack> itemStacks )
 	{
 		super.getSubItems( sameItem, creativeTab, itemStacks );
 	}
+
+	/**
+	 * During registration of the item in the registry, this method is used to determine which models need to be registered for the item to be
+	 * rendered. If your item subclass requires more than just the default, override this method and add them to the list, or replace it entirely.
+	 */
+	@SideOnly( Side.CLIENT )
+	public List<ResourceLocation> getItemVariants() {
+		return Lists.newArrayList( getRegistryName() );
+	}
+
+	/**
+	 * If this item requires special logic to select the model for rendering, this method can be overriden to return that selection logic.
+	 * Return null to use the standard logic.
+	 */
+	@SideOnly( Side.CLIENT )
+	public ItemMeshDefinition getItemMeshDefinition() {
+		return null;
+	}
+
 }

--- a/src/main/java/appeng/items/misc/ItemPaintBall.java
+++ b/src/main/java/appeng/items/misc/ItemPaintBall.java
@@ -30,6 +30,8 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import appeng.api.util.AEColor;
 import appeng.core.features.AEFeature;
@@ -135,6 +137,7 @@ public class ItemPaintBall extends AEBaseItem
 	}
 
 	@Override
+	@SideOnly( Side.CLIENT )
 	public ItemMeshDefinition getItemMeshDefinition()
 	{
 		return is -> isLumen( is ) ? MODEL_SHIMMER : MODEL_NORMAL;

--- a/src/main/java/appeng/items/misc/ItemPaintBall.java
+++ b/src/main/java/appeng/items/misc/ItemPaintBall.java
@@ -22,26 +22,19 @@ package appeng.items.misc;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
+import com.google.common.collect.ImmutableList;
+
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.renderer.color.IBlockColor;
-import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockAccess;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraft.util.ResourceLocation;
 
 import appeng.api.util.AEColor;
-import appeng.client.ClientHelper;
 import appeng.core.features.AEFeature;
 import appeng.core.localization.GuiText;
 import appeng.items.AEBaseItem;
-import appeng.util.Platform;
 
 
 public class ItemPaintBall extends AEBaseItem
@@ -106,5 +99,44 @@ public class ItemPaintBall extends AEBaseItem
 	{
 		final int dmg = is.getItemDamage();
 		return dmg >= DAMAGE_THRESHOLD;
+	}
+
+	public static int getColorFromItemstack( ItemStack stack, int tintIndex )
+	{
+		final AEColor col = ( (ItemPaintBall) stack.getItem() ).getColor( stack );
+
+		final int colorValue = stack.getItemDamage() >= 20 ? col.mediumVariant : col.mediumVariant;
+		final int r = ( colorValue >> 16 ) & 0xff;
+		final int g = ( colorValue >> 8 ) & 0xff;
+		final int b = ( colorValue ) & 0xff;
+
+		if( stack.getItemDamage() >= 20 )
+		{
+			final float fail = 0.7f;
+			final int full = (int) ( 255 * 0.3 );
+			return (int) ( full + r * fail ) << 16 | (int) ( full + g * fail ) << 8 | (int) ( full + b * fail ) | 0xff << 24;
+		}
+		else
+		{
+			return r << 16 | g << 8 | b | 0xff << 24;
+		}
+	}
+
+	private static final ModelResourceLocation MODEL_NORMAL = new ModelResourceLocation( "appliedenergistics2:ItemPaintBall" );
+	private static final ModelResourceLocation MODEL_SHIMMER = new ModelResourceLocation( "appliedenergistics2:ItemPaintBallShimmer" );
+
+	@Override
+	public List<ResourceLocation> getItemVariants()
+	{
+		return ImmutableList.of(
+				MODEL_NORMAL,
+				MODEL_SHIMMER
+		);
+	}
+
+	@Override
+	public ItemMeshDefinition getItemMeshDefinition()
+	{
+		return is -> isLumen( is ) ? MODEL_SHIMMER : MODEL_NORMAL;
 	}
 }


### PR DESCRIPTION
This PR includes a little piece of infrastructure required to do this correctly:
Analogous to the ItemMeshDefinition for Blocks, this adds two methods to AEBaseItem that allow item classes to specify two things for registration: 1) An optional ItemMeshDefinition for custom item model mapping and 2) A list of additional models that are needed for the item.

This infrastructure is then used to fix the display of paintball items.

The logic for determining the actual color value of a paintball itemstack is also moved into the paint ball item class, now using a method reference at the registration location in ClientHelper.

The result:
![Paint Balls](https://i.imgur.com/iV7oHln.jpg)

Comparison shot from 1.7:
![Paint Balls in 1.7](https://i.imgur.com/VYQm0Aa.jpg)
