### PR TITLE
Implemented Seed Growth Stages

### DIFF
--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -31,7 +31,6 @@ import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -232,12 +231,9 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		egc.motionY = location.motionY;
 		egc.motionZ = location.motionZ;
 
-		if( location instanceof EntityItem )
-		{
-			// TODO: DELAY BEFORE PICKUP
-			// NEEDS FIXING?!?!
-			// egc.delayBeforeCanPickup = ( (EntityItem) location ).delayBeforeCanPickup;
-		}
+		// Cannot read the pickup delay of the original item, so we
+		// use the pickup delay used for items dropped by a player instead
+		egc.setPickupDelay(40);
 
 		return egc;
 	}

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -21,12 +21,12 @@ package appeng.items.misc;
 
 import java.util.EnumSet;
 import java.util.List;
-
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
@@ -36,16 +36,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.IMaterials;
 import appeng.api.implementations.items.IGrowableCrystal;
 import appeng.api.recipes.ResolverResult;
-import appeng.client.ClientHelper;
 import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
 import appeng.core.localization.ButtonToolTips;
@@ -91,11 +89,11 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 
 	private static ItemStack newStyle( final ItemStack itemStack )
 	{
-		( (ItemCrystalSeed) itemStack.getItem() ).getProgress( itemStack );
+		getProgress( itemStack );
 		return itemStack;
 	}
 
-	private int getProgress( final ItemStack is )
+	private static int getProgress( final ItemStack is )
 	{
 		if( is.hasTagCompound() )
 		{
@@ -115,7 +113,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	@Override
 	public ItemStack triggerGrowth( final ItemStack is )
 	{
-		final int newDamage = this.getProgress( is ) + 1;
+		final int newDamage = getProgress( is ) + 1;
 		final IMaterials materials = AEApi.instance().definitions().materials();
 		final int size = is.stackSize;
 
@@ -166,7 +164,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	public void addCheckedInformation( final ItemStack stack, final EntityPlayer player, final List<String> lines, final boolean displayMoreInfo )
 	{
 		lines.add( ButtonToolTips.DoesntDespawn.getLocal() );
-		final int progress = this.getProgress( stack ) % SINGLE_OFFSET;
+		final int progress = getProgress( stack ) % SINGLE_OFFSET;
 		lines.add( Math.floor( (float) progress / (float) ( SINGLE_OFFSET / 100 ) ) + "%" );
 
 		super.addCheckedInformation( stack, player, lines, displayMoreInfo );
@@ -181,7 +179,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	@Override
 	public String getUnlocalizedName( final ItemStack is )
 	{
-		final int damage = this.getProgress( is );
+		final int damage = getProgress( is );
 
 		if( damage < CERTUS + SINGLE_OFFSET )
 		{
@@ -262,4 +260,71 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		itemStacks.add( newStyle( new ItemStack( this, 1, LEVEL_OFFSET * 2 + NETHER ) ) );
 		itemStacks.add( newStyle( new ItemStack( this, 1, LEVEL_OFFSET * 2 + FLUIX ) ) );
 	}
+
+	private static final ModelResourceLocation[] MODELS_CERTUS = {
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Certus" ),
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Certus2" ),
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Certus3" )
+	};
+	private static final ModelResourceLocation[] MODELS_FLUIX = {
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Fluix" ),
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Fluix2" ),
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Fluix3" )
+	};
+	private static final ModelResourceLocation[] MODELS_NETHER = {
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Nether" ),
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Nether2" ),
+		new ModelResourceLocation( "appliedenergistics2:ItemCrystalSeed.Nether3" )
+	};
+
+	@Override
+	public List<ResourceLocation> getItemVariants()
+	{
+		return ImmutableList.<ResourceLocation>builder().add( MODELS_CERTUS ).add( MODELS_FLUIX ).add( MODELS_NETHER ).build();
+	}
+
+	@Override
+	public ItemMeshDefinition getItemMeshDefinition()
+	{
+		return is -> {
+			int damage = getProgress( is );
+
+			// Split the damage value into crystal type and growth level
+			int type = damage / SINGLE_OFFSET;
+			int level = ( damage % SINGLE_OFFSET ) / LEVEL_OFFSET;
+
+			// Determine which list of models to use based on the type of crystal
+			ModelResourceLocation[] models;
+			switch( type )
+			{
+				case 0:
+					models = MODELS_CERTUS;
+					break;
+				case 1:
+					models = MODELS_NETHER;
+					break;
+				case 2:
+					models = MODELS_FLUIX;
+					break;
+				default:
+					// We use this as the fallback for broken items
+					models = MODELS_CERTUS;
+					break;
+			}
+
+			// Return one of the 3 models based on the level
+			if( level < 0 )
+			{
+				level = 0;
+			}
+			else if( level >= models.length )
+			{
+				level = models.length - 1;
+			}
+
+			return models[level];
+
+		};
+	}
+
 }

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -38,6 +38,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.IMaterials;
@@ -274,12 +276,14 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 	};
 
 	@Override
+	@SideOnly( Side.CLIENT )
 	public List<ResourceLocation> getItemVariants()
 	{
 		return ImmutableList.<ResourceLocation>builder().add( MODELS_CERTUS ).add( MODELS_FLUIX ).add( MODELS_NETHER ).build();
 	}
 
 	@Override
+	@SideOnly( Side.CLIENT )
 	public ItemMeshDefinition getItemMeshDefinition()
 	{
 		return is -> {


### PR DESCRIPTION
This PR relies on the infrastructure introduced in PR #48. So that one has to be accepted before this one makes any sense to accept. The diff for this PR should update automatically once PR #48 is accepted.

It implements chosing the right model for crystal seeds based on their type and growth stage.
This PR also fixes the pickup delay for dropped seeds. Sadly the original functionality of inheriting the pickup delay seems impossible without an access transformer or reflection hacks, so I defaulted to just use the player-drop pickup delay of 40. 

This makes seed growing functional, which I tested for the certus quartz seed:
![Stage 1](https://i.imgur.com/0l3vTks.jpg)
![Stage 2](https://i.imgur.com/AStXWri.jpg)
![Stage 3](https://i.imgur.com/71MnCrL.jpg)

The last stage is just a missing model since the final result item isn't implemented yet.

Here's an overview of the creative tab:
![Creative Tab](https://i.imgur.com/3741Bfp.jpg)
