### PR TITLE
Implemented display of icons for MultiItem

### DIFF
--- a/src/main/java/appeng/items/materials/MaterialType.java
+++ b/src/main/java/appeng/items/materials/MaterialType.java
@@ -26,8 +26,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import appeng.core.AppEng;
 import appeng.core.features.AEFeature;
@@ -118,8 +116,6 @@ public enum MaterialType
 	CardCrafting( 53 );
 
 	private final EnumSet<AEFeature> features;
-	// TextureAtlasSprite for the material.
-	@SideOnly( Side.CLIENT )
 	private final ModelResourceLocation model = new ModelResourceLocation( "appliedenergistics2:ItemMaterial." + name() );
 	private Item itemInstance;
 	private int damageValue;

--- a/src/main/java/appeng/items/materials/MaterialType.java
+++ b/src/main/java/appeng/items/materials/MaterialType.java
@@ -21,7 +21,7 @@ package appeng.items.materials;
 
 import java.util.EnumSet;
 
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -120,7 +120,7 @@ public enum MaterialType
 	private final EnumSet<AEFeature> features;
 	// TextureAtlasSprite for the material.
 	@SideOnly( Side.CLIENT )
-	private TextureAtlasSprite IIcon;
+	private final ModelResourceLocation model = new ModelResourceLocation( "appliedenergistics2:ItemMaterial." + name() );
 	private Item itemInstance;
 	private int damageValue;
 	// stack!
@@ -221,16 +221,6 @@ public enum MaterialType
 		this.itemInstance = itemInstance;
 	}
 
-	TextureAtlasSprite getIIcon()
-	{
-		return this.IIcon;
-	}
-
-	void setIIcon( final TextureAtlasSprite iIcon )
-	{
-		this.IIcon = iIcon;
-	}
-
 	MaterialStackSrc getStackSrc()
 	{
 		return this.stackSrc;
@@ -239,6 +229,10 @@ public enum MaterialType
 	void setStackSrc( final MaterialStackSrc stackSrc )
 	{
 		this.stackSrc = stackSrc;
+	}
+
+	public ModelResourceLocation getModel() {
+		return model;
 	}
 
 }

--- a/src/main/java/appeng/items/materials/MultiItem.java
+++ b/src/main/java/appeng/items/materials/MultiItem.java
@@ -52,6 +52,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
 
 import appeng.api.config.Upgrades;
@@ -445,6 +447,7 @@ public final class MultiItem extends AEBaseItem implements IStorageComponent, IU
 	}
 
 	@Override
+	@SideOnly( Side.CLIENT )
 	public List<ResourceLocation> getItemVariants()
 	{
 		// Register a resource location for every material type
@@ -455,6 +458,7 @@ public final class MultiItem extends AEBaseItem implements IStorageComponent, IU
 	}
 
 	@Override
+	@SideOnly( Side.CLIENT )
 	public ItemMeshDefinition getItemMeshDefinition()
 	{
 		return is -> getTypeByStack( is ).getModel();

--- a/src/main/java/appeng/items/materials/MultiItem.java
+++ b/src/main/java/appeng/items/materials/MultiItem.java
@@ -30,10 +30,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
+import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
@@ -46,11 +48,10 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
 
 import appeng.api.config.Upgrades;
@@ -61,7 +62,6 @@ import appeng.api.implementations.items.IUpgradeModule;
 import appeng.api.implementations.tiles.ISegmentedInventory;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.SelectedPart;
-import appeng.client.ClientHelper;
 import appeng.core.AEConfig;
 import appeng.core.features.AEFeature;
 import appeng.core.features.IStackSrc;
@@ -143,11 +143,8 @@ public final class MultiItem extends AEBaseItem implements IStorageComponent, IU
 
 	public MaterialType getTypeByStack( final ItemStack is )
 	{
-		if( this.dmgToMaterial.containsKey( is.getItemDamage() ) )
-		{
-			return this.dmgToMaterial.get( is.getItemDamage() );
-		}
-		return MaterialType.InvalidType;
+		MaterialType type = this.dmgToMaterial.get( is.getItemDamage() );
+		return (type != null) ? type : MaterialType.InvalidType;
 	}
 
 	@Override
@@ -446,4 +443,21 @@ public final class MultiItem extends AEBaseItem implements IStorageComponent, IU
 			return o1.compareTo( o2 );
 		}
 	}
+
+	@Override
+	public List<ResourceLocation> getItemVariants()
+	{
+		// Register a resource location for every material type
+		return Arrays.stream( MaterialType.values() )
+				.map( MaterialType::getModel )
+				.collect( Collectors.toList() );
+
+	}
+
+	@Override
+	public ItemMeshDefinition getItemMeshDefinition()
+	{
+		return is -> getTypeByStack( is ).getModel();
+	}
+
 }

--- a/src/main/resources/assets/appliedenergistics2/models/item/ItemMaterial.InvalidType.json
+++ b/src/main/resources/assets/appliedenergistics2/models/item/ItemMaterial.InvalidType.json
@@ -1,0 +1,3 @@
+{
+    "parent":"builtin/missing"
+}


### PR DESCRIPTION
This PR relies on the infrastructure introduced in PR #48. So that one has to be accepted before this one makes any sense to accept. The diff for this PR should update automatically once PR #48 is accepted.

Using the infrastructure from the aforementioned PR I implemented selection of the right models for MultiItem. The models were already all there, so this just selects them for display. Since I made registering the model generic based on the material names, I added a model for the InvalidType material to prevent FML from outputting a loading error to the log.

Screenshot of result from creative tab:
![Multi Item Tab 1](https://i.imgur.com/gqfgRAP.jpg)
![Multi Item Tab 1](https://i.imgur.com/UYwpQTn.jpg)
