### PR TITLE
Slight fix to UVLModelLoader

### DIFF
--- a/src/main/java/appeng/client/render/model/UVLModelLoader.java
+++ b/src/main/java/appeng/client/render/model/UVLModelLoader.java
@@ -13,7 +13,6 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 import com.google.common.base.Charsets;
@@ -154,14 +153,21 @@ public enum UVLModelLoader implements ICustomModelLoader
 	@Override
 	public boolean accepts( ResourceLocation modelLocation )
 	{
-		try
+		// Skip vanilla resources because those will never include UVL models
+		if( modelLocation.getResourceDomain().equals( "minecraft" ) )
 		{
-			return gson.fromJson( new InputStreamReader( Minecraft.getMinecraft().getResourceManager().getResource( modelLocation ).getInputStream() ), UVLMarker.class ).uvlMarker;
+			return false;
+		}
+
+		try( IResource resource = Minecraft.getMinecraft().getResourceManager().getResource( modelLocation ) )
+		{
+			return gson.fromJson( new InputStreamReader( resource.getInputStream() ), UVLMarker.class ).uvlMarker;
 		}
 		catch( IOException e )
 		{
 
 		}
+
 		return false;
 	}
 

--- a/src/main/java/appeng/client/render/model/UVLModelLoader.java
+++ b/src/main/java/appeng/client/render/model/UVLModelLoader.java
@@ -159,16 +159,17 @@ public enum UVLModelLoader implements ICustomModelLoader
 			return false;
 		}
 
-		try( IResource resource = Minecraft.getMinecraft().getResourceManager().getResource( modelLocation ) )
+		ResourceLocation actualLoc = new ResourceLocation( modelLocation.getResourceDomain(), modelLocation.getResourcePath() + ".json" );
+
+		try( IResource resource = Minecraft.getMinecraft().getResourceManager().getResource( actualLoc ) )
 		{
 			return gson.fromJson( new InputStreamReader( resource.getInputStream() ), UVLMarker.class ).uvlMarker;
 		}
 		catch( IOException e )
 		{
-
+			return false;
 		}
 
-		return false;
 	}
 
 	@Override


### PR DESCRIPTION
This fixes an issue in UVLModelLoader where it would not close the resources it opens to inspect them for the uvlMarker tag.

In addition, it optimizes loading times slightly by skipping Vanilla resources.
