### PR TITLE
Controller UVL Fix

### DIFF
--- a/src/main/resources/assets/appliedenergistics2/blockstates/tile.BlockController.json
+++ b/src/main/resources/assets/appliedenergistics2/blockstates/tile.BlockController.json
@@ -6,11 +6,11 @@
     },
     {
       "when": { "type": "block", "state": "online" },
-      "apply": { "model": "appliedenergistics2:controller/controller_block_online.uvl" }
+      "apply": { "model": "appliedenergistics2:controller/controller_block_online" }
     },
     {
       "when": { "type": "block", "state": "conflicted" },
-      "apply": { "model": "appliedenergistics2:controller/controller_block_conflicted.uvl" }
+      "apply": { "model": "appliedenergistics2:controller/controller_block_conflicted" }
     },
     {
       "when": { "type": "column", "state": "offline" },
@@ -18,11 +18,11 @@
     },
     {
       "when": { "type": "column", "state": "online" },
-      "apply": { "model": "appliedenergistics2:controller/controller_column_online.uvl" }
+      "apply": { "model": "appliedenergistics2:controller/controller_column_online" }
     },
     {
       "when": { "type": "column", "state": "conflicted" },
-      "apply": { "model": "appliedenergistics2:controller/controller_column_conflicted.uvl" }
+      "apply": { "model": "appliedenergistics2:controller/controller_column_conflicted" }
     },
     {
       "when": { "type": "inside_a", "state": "offline|online|conflicted" },

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_conflicted.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_conflicted.json
@@ -1,4 +1,5 @@
 {
+    "uvlMarker": true,
     "parent": "block/block",
     "display": {
         "firstperson_righthand": {
@@ -9,8 +10,8 @@
     },
     "textures": {
         "particle": "#block",
-        "block": "appliedenergistics2:blocks/BlockControllerColumnPowered",
-        "lights": "appliedenergistics2:blocks/BlockControllerColumnConflict"
+        "block": "appliedenergistics2:blocks/BlockControllerPowered",
+        "lights": "appliedenergistics2:blocks/BlockControllerConflict"
     },
     "elements": [
         {

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_online.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_block_online.json
@@ -1,4 +1,5 @@
 {
+    "uvlMarker": true,
     "parent": "block/block",
     "display": {
         "firstperson_righthand": {
@@ -9,8 +10,8 @@
     },
     "textures": {
         "particle": "#block",
-        "block": "appliedenergistics2:blocks/BlockControllerColumnPowered",
-        "lights": "appliedenergistics2:blocks/BlockControllerColumnLights"
+        "block": "appliedenergistics2:blocks/BlockControllerPowered",
+        "lights": "appliedenergistics2:blocks/BlockControllerLights"
     },
     "elements": [
         {

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_conflicted.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_conflicted.json
@@ -1,4 +1,5 @@
 {
+    "uvlMarker": true,
     "parent": "block/block",
     "display": {
         "firstperson_righthand": {
@@ -9,8 +10,8 @@
     },
     "textures": {
         "particle": "#block",
-        "block": "appliedenergistics2:blocks/BlockControllerPowered",
-        "lights": "appliedenergistics2:blocks/BlockControllerLights"
+        "block": "appliedenergistics2:blocks/BlockControllerColumnPowered",
+        "lights": "appliedenergistics2:blocks/BlockControllerColumnLights"
     },
     "elements": [
         {

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_conflicted.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_conflicted.json
@@ -11,7 +11,7 @@
     "textures": {
         "particle": "#block",
         "block": "appliedenergistics2:blocks/BlockControllerColumnPowered",
-        "lights": "appliedenergistics2:blocks/BlockControllerColumnLights"
+        "lights": "appliedenergistics2:blocks/BlockControllerColumnConflict"
     },
     "elements": [
         {

--- a/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_online.json
+++ b/src/main/resources/assets/appliedenergistics2/models/block/controller/controller_column_online.json
@@ -1,4 +1,5 @@
 {
+    "uvlMarker": true,
     "parent": "block/block",
     "display": {
         "firstperson_righthand": {
@@ -9,8 +10,8 @@
     },
     "textures": {
         "particle": "#block",
-        "block": "appliedenergistics2:blocks/BlockControllerPowered",
-        "lights": "appliedenergistics2:blocks/BlockControllerConflict"
+        "block": "appliedenergistics2:blocks/BlockControllerColumnPowered",
+        "lights": "appliedenergistics2:blocks/BlockControllerColumnLights"
     },
     "elements": [
         {


### PR DESCRIPTION
Controller models now use the new way of marking them for use with the UVL Model Loader.

No parent model is still used because Vanilla models can't have non-vanilla parents, apparently.
