### PR TITLE
Fixes Pickup Delay

### DIFF
--- a/src/main/java/appeng/items/materials/MultiItem.java
+++ b/src/main/java/appeng/items/materials/MultiItem.java
@@ -71,6 +71,7 @@ import appeng.core.features.MaterialStackSrc;
 import appeng.items.AEBaseItem;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
+import appeng.util.item.PickupDelayHelper;
 
 
 public final class MultiItem extends AEBaseItem implements IStorageComponent, IUpgradeModule
@@ -358,9 +359,7 @@ public final class MultiItem extends AEBaseItem implements IStorageComponent, IU
 
 		if( location instanceof EntityItem && eqi instanceof EntityItem )
 		{
-			// TODO: Entity Pick up time?
-			// needs fixing?
-			// ( (EntityItem) eqi ).setPickupDelay( ( (EntityItem) location ).pick;
+			PickupDelayHelper.copyPickupDelay( location, (EntityItem) eqi );
 		}
 
 		return eqi;

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -31,7 +31,6 @@ import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -235,7 +234,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		egc.motionY = location.motionY;
 		egc.motionZ = location.motionZ;
 
-		egc.setPickupDelay( PickupDelayHelper.getPickupDelay( (EntityItem) location ) );
+		PickupDelayHelper.copyPickupDelay( location, egc );
 
 		return egc;
 	}

--- a/src/main/java/appeng/items/misc/ItemCrystalSeed.java
+++ b/src/main/java/appeng/items/misc/ItemCrystalSeed.java
@@ -31,6 +31,7 @@ import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -52,6 +53,7 @@ import appeng.entity.EntityGrowingCrystal;
 import appeng.entity.EntityIds;
 import appeng.items.AEBaseItem;
 import appeng.util.Platform;
+import appeng.util.item.PickupDelayHelper;
 
 
 public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
@@ -233,9 +235,7 @@ public class ItemCrystalSeed extends AEBaseItem implements IGrowableCrystal
 		egc.motionY = location.motionY;
 		egc.motionZ = location.motionZ;
 
-		// Cannot read the pickup delay of the original item, so we
-		// use the pickup delay used for items dropped by a player instead
-		egc.setPickupDelay(40);
+		egc.setPickupDelay( PickupDelayHelper.getPickupDelay( (EntityItem) location ) );
 
 		return egc;
 	}

--- a/src/main/java/appeng/util/item/PickupDelayHelper.java
+++ b/src/main/java/appeng/util/item/PickupDelayHelper.java
@@ -1,0 +1,49 @@
+package appeng.util.item;
+
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+
+/**
+ * Small helper class that allows one to get the pickup delay of an entity, if it is an item.
+ */
+public final class PickupDelayHelper
+{
+
+	private static final MethodHandle pickupDelayGetter = generateGetter();
+
+	private PickupDelayHelper()
+	{
+	}
+
+	public static int getPickupDelay( EntityItem entity )
+	{
+		try
+		{
+			return (Integer) pickupDelayGetter.invoke( entity );
+		}
+		catch( Throwable throwable )
+		{
+			throw new RuntimeException( "Unable to retrieve delayBeforeCanPickup", throwable );
+		}
+	}
+
+	private static MethodHandle generateGetter()
+	{
+		Field field = ReflectionHelper.findField( EntityItem.class, "delayBeforeCanPickup", "field_145804_b" );
+
+		try
+		{
+			return MethodHandles.lookup().unreflectGetter( field );
+		}
+		catch( IllegalAccessException e )
+		{
+			throw new RuntimeException( "Unable to create a getter for delayBeforeCanPickup!", e );
+		}
+	}
+}

--- a/src/main/java/appeng/util/item/PickupDelayHelper.java
+++ b/src/main/java/appeng/util/item/PickupDelayHelper.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2013 - 2015, AlgorithmX2, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
 package appeng.util.item;
 
 

--- a/src/main/java/appeng/util/item/PickupDelayHelper.java
+++ b/src/main/java/appeng/util/item/PickupDelayHelper.java
@@ -5,8 +5,11 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
+import appeng.core.AELog;
 
 
 /**
@@ -15,7 +18,7 @@ import net.minecraftforge.fml.relauncher.ReflectionHelper;
 public final class PickupDelayHelper
 {
 
-	private static final MethodHandle pickupDelayGetter = generateGetter();
+	private static final MethodHandle pickupDelayGetter = generatePickupDelayGetter();
 
 	private PickupDelayHelper()
 	{
@@ -29,11 +32,29 @@ public final class PickupDelayHelper
 		}
 		catch( Throwable throwable )
 		{
-			throw new RuntimeException( "Unable to retrieve delayBeforeCanPickup", throwable );
+			AELog.warn( throwable, "Unable to get item delayBeforeCanPickup for entity " + entity );
+			return 40; // Default for player-thrown objects
 		}
 	}
 
-	private static MethodHandle generateGetter()
+	/**
+	 * Copies the pickup delay from the given entity to the given target entity. If the source entity is not
+	 * an item, a default pickup delay is used for the target.
+	 */
+	public static void copyPickupDelay( Entity from, EntityItem to )
+	{
+
+		if( from instanceof EntityItem )
+		{
+			to.setPickupDelay( getPickupDelay( (EntityItem) from ) );
+		}
+		else
+		{
+			to.setDefaultPickupDelay();
+		}
+	}
+
+	private static MethodHandle generatePickupDelayGetter()
 	{
 		Field field = ReflectionHelper.findField( EntityItem.class, "delayBeforeCanPickup", "field_145804_b" );
 


### PR DESCRIPTION
There were two places where delayBeforeCanPickup was commented out because it was made private.

This PR restores the original behavior by using a Reflection based utility to get the value of the field.
MethodHandles are used for improved performance.
