### PR TITLE
Tint related crashes and bugs

### DIFF
--- a/src/main/java/appeng/client/render/model/CachingRotatingBakedModel.java
+++ b/src/main/java/appeng/client/render/model/CachingRotatingBakedModel.java
@@ -216,7 +216,7 @@ public class CachingRotatingBakedModel implements IBakedModel
 
 		public void setQuadTint( int tint )
 		{
-
+			parent.setQuadTint( tint );
 		}
 
 		@Override
@@ -228,13 +228,13 @@ public class CachingRotatingBakedModel implements IBakedModel
 		@Override
 		public void setApplyDiffuseLighting( boolean diffuse )
 		{
-
+			parent.setApplyDiffuseLighting( diffuse );
 		}
 
 		@Override
 		public void setTexture( TextureAtlasSprite texture )
 		{
-
+			parent.setTexture( texture );
 		}
 
 	}

--- a/src/main/java/appeng/client/render/model/UVLModelLoader.java
+++ b/src/main/java/appeng/client/render/model/UVLModelLoader.java
@@ -315,9 +315,15 @@ public enum UVLModelLoader implements ICustomModelLoader
 							lightmap[1] = brightness.getLeft();
 						}
 
+						@Override
+						public void setQuadTint( int tint )
+						{
+							// Tint requires a block state which we don't have at this point
+						}
 					};
 					trans.setParent( builder );
 					quad.pipe( trans );
+					builder.setQuadTint( quad.getTintIndex() );
 					builder.setQuadOrientation( quad.getFace() );
 					return builder.build();
 				}


### PR DESCRIPTION
Fixes a crash bug when trying to break a block because the damage texture couldn't be generated. This was caused by CachingRotatingBakedModel not setting the texture on the output quads.

Fixes another crash bug when trying to load an UVL model with tint indices. This was caused by the vertex lighter in UVL model loader trying to access the non-existing block state to get the color multiplier. Fixed by emulating tint -1 during this lighting step.

Both classes also failed to propagate the tint-index to the resulting quads, so tint didn't work ingame anymore.
