### PR TITLE
Moving to semver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ apply from: 'gradle/scripts/integration.gradle'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-version = aeversion + "-" + aechannel + "-" + aebuild
+version = "${aeversion}.${aeminor}.${aebuild}-$aechannel"
 group = aegroup
 archivesBaseName = aebasename
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
-aeversion=rv3
-aechannel=alpha
+aeversion=3
+aeminor=0
 aebuild=0
+aechannel=alpha
 aegroup=appeng
 aebasename=appliedenergistics2
 

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -54,7 +54,6 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
 	public static final double TUNNEL_POWER_LOSS = 0.05;
 	public static final String VERSION = "@version@";
-	public static final String CHANNEL = "@aechannel@";
 	public static final String PACKET_CHANNEL = "AE";
 	public static AEConfig instance;
 	public final IConfigManager settings = new ConfigManager( this );

--- a/src/main/java/appeng/core/crash/ModCrashEnhancement.java
+++ b/src/main/java/appeng/core/crash/ModCrashEnhancement.java
@@ -7,8 +7,8 @@ import appeng.core.AEConfig;
 
 public class ModCrashEnhancement extends BaseCrashEnhancement
 {
-	private static final String MOD_VERSION = AEConfig.CHANNEL + ' ' + AEConfig.VERSION + " for Forge " + // WHAT?
-	net.minecraftforge.common.ForgeVersion.majorVersion + '.' // majorVersion
+	private static final String MOD_VERSION = AEConfig.VERSION + " for Forge " + // WHAT?
+			net.minecraftforge.common.ForgeVersion.majorVersion + '.' // majorVersion
 			+ net.minecraftforge.common.ForgeVersion.minorVersion + '.' // minorVersion
 			+ net.minecraftforge.common.ForgeVersion.revisionVersion + '.' // revisionVersion
 			+ net.minecraftforge.common.ForgeVersion.buildVersion;


### PR DESCRIPTION
Made versioning fully conform to [semver](http://semver.org/).
Added minor ae version (required for semver).

Examples (in examples minor version is unused):

| Current | Semver |
| --- | --- |
| release rv3 build 27 | 2.0.27-release |
| alpha rv5 build 11 | 5.0.11-alpha |
