### PR TITLE
stackSize Fixes in place.

### DIFF
--- a/src/main/java/appeng/core/lib/api/definitions/ApiBlocks.java
+++ b/src/main/java/appeng/core/lib/api/definitions/ApiBlocks.java
@@ -518,7 +518,7 @@ public final class ApiBlocks// implements IBlocks
 	}
 
 	/* @Override */
-	//todo: Number of arguments error at this point. need to check class. -legracen
+	//TODO: Number of arguments error at this point. need to check class. -legracen
 	public ITileDefinition<? extends TileEntity, Class<? extends TileEntity>> paint()
 	{
 		return this.paint;

--- a/src/main/java/appeng/core/lib/api/definitions/ApiItems.java
+++ b/src/main/java/appeng/core/lib/api/definitions/ApiItems.java
@@ -20,7 +20,7 @@ package appeng.core.lib.api.definitions;
 
 
 import appeng.api.definitions.IItemDefinition;
-//todo: AEColoredItemDefinition class does not exist. -legracen
+//TODO: AEColoredItemDefinition class does not exist. -legracen
 import appeng.core.api.util.AEColoredItemDefinition;
 import appeng.core.crafting.item.ItemEncodedPattern;
 import appeng.core.item.ItemCrystalSeed;

--- a/src/main/java/appeng/core/lib/api/definitions/ApiMaterials.java
+++ b/src/main/java/appeng/core/lib/api/definitions/ApiMaterials.java
@@ -32,7 +32,7 @@ import appeng.core.item.MaterialType;
 import appeng.core.lib.bootstrap.FeatureFactory;
 import appeng.core.lib.bootstrap.IItemRendering;
 import appeng.core.lib.bootstrap.ItemRenderingCustomizer;
-//todo: DamagedItemDefinition class does not curently exist. -legracen
+//TODO: DamagedItemDefinition class does not curently exist. -legracen
 import appeng.core.lib.features.DamagedItemDefinition;
 
 

--- a/src/main/java/appeng/core/lib/api/definitions/ApiParts.java
+++ b/src/main/java/appeng/core/lib/api/definitions/ApiParts.java
@@ -22,7 +22,7 @@ package appeng.core.lib.api.definitions;
 import appeng.api.definitions.IItemDefinition;
 import appeng.core.api.exceptions.MissingDefinition;
 import appeng.core.lib.bootstrap.FeatureFactory;
-//todo: DamagedItemDefinition class does not exist. -legracen
+//TODO: DamagedItemDefinition class does not exist. -legracen
 import appeng.core.lib.features.DamagedItemDefinition;
 import appeng.core.me.api.parts.IPartHelper;
 import appeng.core.me.item.ItemMultiPart;

--- a/src/main/java/appeng/core/lib/block/AEBaseBlock.java
+++ b/src/main/java/appeng/core/lib/block/AEBaseBlock.java
@@ -66,6 +66,7 @@ public abstract class AEBaseBlock extends Block
 
 	protected AxisAlignedBB boundingBox = FULL_BLOCK_AABB;
 
+	//TODO: method does not override or implement a method from a supertype. -Legracen
 	@Override
 	public boolean isVisuallyOpaque(IBlockState state)
 	{
@@ -177,10 +178,10 @@ public abstract class AEBaseBlock extends Block
 		{
 			if( Platform.isClient() )
 			{
-				final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+				final EntityPlayer player = Minecraft.getMinecraft().player;//Renamed in 1.11 Minecraft.getMinecraft().thePlayer;
 				final LookDirection ld = Platform.getPlayerRay( player, Platform.getEyeOffset( player ) );
 
-				final Iterable<AxisAlignedBB> bbs = collisionHandler.getSelectedBoundingBoxesFromPool( w, pos, Minecraft.getMinecraft().thePlayer, true );
+				final Iterable<AxisAlignedBB> bbs = collisionHandler.getSelectedBoundingBoxesFromPool( w, pos, Minecraft.getMinecraft().player, true );
 				AxisAlignedBB br = null;
 
 				double lastDist = 0;

--- a/src/main/java/appeng/core/lib/bootstrap/ItemSubDefinitionsProvider.java
+++ b/src/main/java/appeng/core/lib/bootstrap/ItemSubDefinitionsProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.util.ResourceLocation;
 import appeng.api.definitions.IItemDefinition;
 import appeng.api.definitions.sub.ISubDefinitionProperty;
 import appeng.core.lib.bootstrap.ItemSubDefinitionsProvider.IStateItemSubDefinition;
+import appeng.core.lib.features.SubDefinitionsProvider.SubDefinition;
 import appeng.core.lib.features.SubDefinitionsProvider;
 import appeng.core.lib.item.IStateItem;
 import appeng.core.lib.item.IStateItem.State;
@@ -58,7 +59,7 @@ public class ItemSubDefinitionsProvider<I extends Item & IStateItem> extends Sub
 		return new IStateItemSubDefinition( identifier, instance, properties );
 	}
 
-	//todo: SubDefinition class not validating here. -legracen
+	//TODO: SubDefinition class not validating here. -legracen
 	public class IStateItemSubDefinition extends SubDefinition<IStateItemSubDefinition>
 	{
 

--- a/src/main/java/appeng/core/lib/container/slot/AppEngCraftingSlot.java
+++ b/src/main/java/appeng/core/lib/container/slot/AppEngCraftingSlot.java
@@ -85,8 +85,8 @@ public class AppEngCraftingSlot extends AppEngSlot
 	@Override
 	protected void onCrafting( final ItemStack par1ItemStack )
 	{
-		//TODO: worldObj not found attempting to use .world instead here. -legracen
-		par1ItemStack.onCrafting( this.thePlayer.world, this.thePlayer, this.amountCrafted );//.worldObj, this.thePlayer, this.amountCrafted );
+		//TODO: worldObj not found attempting to use .getEntityWorld() instead here. -legracen
+		par1ItemStack.onCrafting( this.thePlayer.getEntityWorld(), this.thePlayer, this.amountCrafted );//.worldObj, this.thePlayer, this.amountCrafted );
 		this.amountCrafted = 0;
 
 		if( par1ItemStack.getItem() == Item.getItemFromBlock( Blocks.CRAFTING_TABLE ) )

--- a/src/main/java/appeng/core/lib/container/slot/AppEngCraftingSlot.java
+++ b/src/main/java/appeng/core/lib/container/slot/AppEngCraftingSlot.java
@@ -85,7 +85,8 @@ public class AppEngCraftingSlot extends AppEngSlot
 	@Override
 	protected void onCrafting( final ItemStack par1ItemStack )
 	{
-		par1ItemStack.onCrafting( this.thePlayer.worldObj, this.thePlayer, this.amountCrafted );
+		//TODO: worldObj not found attempting to use .world instead here. -legracen
+		par1ItemStack.onCrafting( this.thePlayer.world, this.thePlayer, this.amountCrafted );//.worldObj, this.thePlayer, this.amountCrafted );
 		this.amountCrafted = 0;
 
 		if( par1ItemStack.getItem() == Item.getItemFromBlock( Blocks.CRAFTING_TABLE ) )
@@ -139,7 +140,7 @@ public class AppEngCraftingSlot extends AppEngSlot
 		}
 	}
 
-	//todo: bad overide. -legracen
+	//TODO: bad overide possibly fixed need verification. -legracen
 	@Override
 	public void onPickupFromSlot( final EntityPlayer playerIn, final ItemStack stack )
 	{
@@ -153,8 +154,8 @@ public class AppEngCraftingSlot extends AppEngSlot
 			ic.setInventorySlotContents( x, this.craftMatrix.getStackInSlot( x ) );
 		}
 
-		//todo: need to fix implementation of ItemStack. -legracen
-		final ItemStack[] aitemstack = CraftingManager.getInstance().getRemainingItems( ic, playerIn.worldObj );
+		//TODO: worldObj not found attempting to use .world instead here. also error with aitemstack definition possible. -legracen
+		final ItemStack[] aitemstack = CraftingManager.getInstance().getRemainingItems( ic, playerIn.getEntityWorld());
 
 		for( int x = 0; x < this.craftMatrix.getSizeInventory(); x++ )
 		{
@@ -170,8 +171,7 @@ public class AppEngCraftingSlot extends AppEngSlot
 
 			if( itemstack1 != null )
 			{
-				//todo: fix decStackSize in super class. -legracen
-				this.craftMatrix.decStackSize( i, 1 );
+				this.craftMatrix.decrStackSize( i, 1 );
 			}
 
 			if( itemstack2 != null )
@@ -192,17 +192,14 @@ public class AppEngCraftingSlot extends AppEngSlot
 	 * Decrease the size of the stack in slot (first int arg) by the amount of the second int arg. Returns the new
 	 * stack.
 	 */
-	//todo: fix bad override. -legracen
 	@Override
 	public ItemStack decStackSize( final int par1 )
 	{
 		if( this.getHasStack() )
 		{
-			//todo: stackSize is private now. -legracen
-			this.amountCrafted += Math.min( par1, this.getStack().stackSize );
+			this.amountCrafted += Math.min( par1, this.getStack().getCount() );
 		}
 
-		//todo: fix decStackSize in super class. -legracen
-		return super.decStackSize( par1 );
+		return super.decrStackSize( par1 );
 	}
 }

--- a/src/main/java/appeng/core/lib/container/slot/SlotFake.java
+++ b/src/main/java/appeng/core/lib/container/slot/SlotFake.java
@@ -32,13 +32,13 @@ public class SlotFake extends AppEngSlot
 		super( inv, idx, x, y );
 	}
 
-	//todo: bad override. -legracen
+	//TODO: bad override. -legracen
 	@Override
 	public void onPickupFromSlot( final EntityPlayer par1EntityPlayer, final ItemStack par2ItemStack )
 	{
 	}
 
-	//todo: bad override. -legracen
+	//TODO: bad override. -legracen
 	@Override
 	public ItemStack decStackSize( final int par1 )
 	{

--- a/src/main/java/appeng/core/lib/features/registries/P2PTunnelRegistry.java
+++ b/src/main/java/appeng/core/lib/features/registries/P2PTunnelRegistry.java
@@ -28,7 +28,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-//todo: FluidContainerRegistry has been removed need to find fix. --legracen
+//TODO: FluidContainerRegistry has been removed need to find fix. --legracen
 import net.minecraftforge.fluids.FluidContainerRegistry;
 
 import net.minecraftforge.fml.common.registry.GameRegistry;

--- a/src/main/java/appeng/core/lib/sync/GuiBridge.java
+++ b/src/main/java/appeng/core/lib/sync/GuiBridge.java
@@ -34,7 +34,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.IGuiHandler;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
-//todo: IComparableDefinition class not available. -legracen
+//TODO: IComparableDefinition class not available. -legracen
 import appeng.api.definitions.IComparableDefinition;
 import appeng.core.api.config.SecurityPermissions;
 import appeng.core.api.exceptions.AppEngException;

--- a/src/main/java/appeng/core/lib/sync/packets/PacketClick.java
+++ b/src/main/java/appeng/core/lib/sync/packets/PacketClick.java
@@ -28,7 +28,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 
-//todo: IComparableDefinition does not curently exist. commenting out for now. -legracen
+//TODO: IComparableDefinition does not curently exist. commenting out for now. -legracen
 import appeng.api.definitions.IComparableDefinition;
 import appeng.core.api.implementations.items.IMemoryCard;
 import appeng.core.api.implementations.items.MemoryCardMessages;

--- a/src/main/java/appeng/core/lib/tile/inventory/AppEngInternalInventory.java
+++ b/src/main/java/appeng/core/lib/tile/inventory/AppEngInternalInventory.java
@@ -33,7 +33,7 @@ import appeng.core.lib.util.iterators.InvIterator;
 import appeng.core.me.api.storage.IMEInventory;
 import appeng.core.me.grid.storage.MEIInventoryWrapper;
 
-//todo: error not overiding decrStackSize(int,int) properly here. -legracen
+//TODO: error not overiding decrStackSize(int,int) properly here. -legracen
 public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
 {
 	private final int size;
@@ -79,7 +79,7 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
 		return this.inv[var1];
 	}
 
-	//todo: bad override. -legracen
+	//TODO: bad override. -legracen
 	@Override
 	public ItemStack decStackSize( final int slot, final int qty )
 	{
@@ -137,15 +137,13 @@ public class AppEngInternalInventory implements IInventory, Iterable<ItemStack>
 				if( oldStack.func_190916_E() > newItemStack.func_190916_E() )
 				{
 					removed = removed.copy();
-					//todo: 1.11 makes stackSize private. -legracen
-					removed.stackSize -= newItemStack.func_190916_E();
+					removed.shrink(newItemStack.func_190916_E());
 					added = null;
 				}
 				else if( oldStack.func_190916_E() < newItemStack.func_190916_E() )
 				{
 					added = added.copy();
-					//todo: 1.11 makes stackSize private. -legracen
-					added.stackSize -= oldStack.func_190916_E();
+					added.shrink(oldStack.func_190916_E());
 					removed = null;
 				}
 				else

--- a/src/main/java/appeng/core/me/part/AEBasePart.java
+++ b/src/main/java/appeng/core/me/part/AEBasePart.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import appeng.core.lib.util.item.AEItemStack;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -120,7 +121,7 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 	}
 
 	private final AENetworkProxy proxy;
-	private final ItemStack is;
+	public final ItemStack is;
 	private TileEntity tile = null;
 	private IPartHost host = null;
 	private AEPartLocation side = null;
@@ -164,15 +165,13 @@ public abstract class AEBasePart implements IPart, IGridProxyable, IActionHost, 
 	@Override
 	public void securityBreak()
 	{
-		//todo: 1.11 makes stackSize private. -legracen
-		if( this.getItemStack().stackSize > 0 )
+		if( this.getItemStack().getCount() > 0)
 		{
 			final List<ItemStack> items = new ArrayList<ItemStack>();
 			items.add( this.is.copy() );
 			this.host.removePart( this.side, false );
 			Platform.spawnDrops( this.tile.getWorld(), this.tile.getPos(), items );
-			//todo: 1.11 makes stackSize private. -legracen
-			this.is.stackSize = 0;
+			this.is.setCount(0);
 		}
 	}
 

--- a/src/main/java/appeng/core/me/part/reporting/PartPatternTerminal.java
+++ b/src/main/java/appeng/core/me/part/reporting/PartPatternTerminal.java
@@ -150,8 +150,7 @@ public class PartPatternTerminal extends AbstractPartTerminal
 				final ItemStack is = this.crafting.getStackInSlot( x );
 				if( is != null )
 				{
-					//todo: 1.11 makes stackSize private. -legracen
-					is.stackSize = 1;
+					is.setCount(1);
 				}
 			}
 		}

--- a/src/main/java/appeng/core/recipes/AEItemResolver.java
+++ b/src/main/java/appeng/core/recipes/AEItemResolver.java
@@ -26,7 +26,7 @@ import appeng.core.api.recipes.ISubItemResolver;
 import appeng.core.api.recipes.ResolverResult;
 import appeng.core.api.recipes.ResolverResultSet;
 import appeng.core.api.util.AEColor;
-//todo: AEColoredItemDefinition class is not available. commenting out until it can be implemented. -legracen
+//TODO: AEColoredItemDefinition class is not available. commenting out until it can be implemented. -legracen
 import appeng.core.api.util.AEColoredItemDefinition;
 import appeng.core.item.ItemCrystalSeed;
 import appeng.core.item.ItemMultiItem;

--- a/src/main/java/appeng/core/recipes/game/FacadeRecipe.java
+++ b/src/main/java/appeng/core/recipes/game/FacadeRecipe.java
@@ -31,7 +31,7 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 
-//todo: IComparableDefinition class is unavailable commenting out for now. -legracen
+//TODO: IComparableDefinition class is unavailable commenting out for now. -legracen
 import appeng.api.definitions.IComparableDefinition;
 import appeng.core.lib.ApiDefinitions;
 import appeng.core.lib.AppEngApi;
@@ -40,7 +40,7 @@ import appeng.decorative.item.ItemFacade;
 
 public final class FacadeRecipe implements IRecipe
 {
-	//todo: IComparableDefinition class is unavailable commenting out for now. -legracen
+	//TODO: IComparableDefinition class is unavailable commenting out for now. -legracen
 	private final IComparableDefinition anchor;
 	private final Optional<Item> maybeFacade;
 

--- a/src/main/java/appeng/core/tile/TileInscriber.java
+++ b/src/main/java/appeng/core/tile/TileInscriber.java
@@ -36,7 +36,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-//todo: IComparableDefinition class not available. commenting out until it is. -legracen
+//TODO: IComparableDefinition class not available. commenting out until it is. -legracen
 import appeng.api.definitions.IComparableDefinition;
 import appeng.api.definitions.IItemDefinition;
 import appeng.api.definitions.ITileDefinition;


### PR DESCRIPTION
1. Fixed stackSize compile errors due to the 1.11 code change to make it private.
2. Corrected todo: to TODO: for consistency with the rest of the team.
3. Flagged some changes for the .worldOBJ calls that need further investigation where i changed to a new method.
4. fixed the decr Method. (I think. needs further testing once restructuring is done.)
